### PR TITLE
Use mkdirp

### DIFF
--- a/lib/cordovacli.js
+++ b/lib/cordovacli.js
@@ -12,7 +12,7 @@ var path = require('path'),
     extend = require('xtend'),
     async = require('async'),
     spawn = require('child_process').spawn,
-    mkdirp = require("mkdirp-then"),
+    mkdirp = require("mkdirp"),
     log = console.error.bind(console);
 
 
@@ -130,7 +130,8 @@ module.exports = function () {
         // cordova create <PATH> [ID] [NAME]
         var args = ['create', options.path, options.id, options.name].concat(options.args);
         if(options.path) {
-          mkdirp(options.path).then(function(){
+		  mkdirp(options.path, function(err){
+			if(err) return done(err);
             runCordova(args, {}, done);
           });
         } else {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "cordova": "^5.0.0",
     "es6-promise": "^2.2.0",
     "fs-extra": "^0.19.0",
-    "mkdirp-then": "^1.0.1",
+    "mkdirp": "^0.5.1",
     "multi-glob": "^0.4.0",
     "pdenodeify": "^0.1.0",
     "rimraf": "^2.4.0",


### PR DESCRIPTION
This updates the mkdirp-then dependency to use mkdirp instead. The
reason for this is an NPM3 issue and because mkdirp-then depends on
mkdirp "0", it's explained here:

https://github.com/fs-utils/mkdirp-then/issues/2