### PR TITLE
Support Steal 1.0

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -75,8 +75,9 @@ module.exports = function(cordovaOptions) {
 
 	stealCordova.build = function(buildResult){
 		return stealCordova.initIfNeeded().then(function(){
-			var bundlesPath = buildResult.configuration.bundlesPath;
-			return stealCordova.copyProductionFiles(bundlesPath);
+			var config = buildResult.configuration;
+			var destPath = config.dest || config.bundlesPath;
+			return stealCordova.copyProductionFiles(destPath);
 		}).then(function(){
 			return runCli({}, {
 				command: ["build"],


### PR DESCRIPTION
This makes it so that we support steal 1.0. Steal 1.0 has a new destPath
which is the entire dist/ folder. We want to make that folder now and
not just the dist/bundles folder.