### PR TITLE
Refactor code for better readability

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,129 +1,8 @@
-var assert = require("assert");
-var cli = require("./cordovacli")();
-var Promise = require("es6-promise").Promise;
-var extend = require("xtend");
-var path = require("path");
-var fs = require("fs-extra");
-var asap = require("pdenodeify");
-var copy = asap(fs.copy);
-var glob = asap(require("multi-glob").glob);
-
-var slice = Array.prototype.slice;
+var StealCordova = require("./steal-cordova");
 
 // Allow aliasing certain options to make consistent with steal-nw
 var aliases = {
 	buildDir: "path"
-};
-
-module.exports = function(cordovaOptions) {
-	setAliases(cordovaOptions);
-
-	var stealCordova = {};
-
-	stealCordova.init = function(opts){
-		return stealCordova.runCli(opts, {
-			command: ["create", "platform", "plugin"]
-		});
-	};
-
-	// Only initialize if it hasn't already been.
-	stealCordova.initIfNeeded = function(opts){
-		var buildPath = (opts && opts.path) || cordovaOptions.path;
-		assert(!!buildPath, "Path needs to be provided");
-
-		var p = path.resolve(buildPath);
-
-		return new Promise(function(resolve, reject){
-			fs.exists(p, function(doesExist){
-				if(doesExist) {
-					resolve();
-				} else {
-					stealCordova.init(opts)
-					.then(function() {
-						resolve();
-					})
-					.catch(reject);
-				}
-			});
-		});
-	};
-
-	stealCordova.copyProductionFiles = function(bundlesPath){
-		var index = path.resolve(cordovaOptions.index);
-		var dest = path.resolve(cordovaOptions.path, "www/");
-
-		var files = cordovaOptions.files || cordovaOptions.glob || [];
-		files.unshift(bundlesPath);
-
-		return glob(files).then(function(files){
-			var copies = files.map(function(file){
-				return copy(file, destPath(file));
-			});
-			// copy the index.html file
-			copies.push(copy(index, path.join(dest, "index.html")));
-
-			return Promise.all(copies);
-		});
-
-
-		function destPath(p){
-			return path.join(dest, path.relative(process.cwd(), p));
-		}
-	};
-
-	stealCordova.platform = function(opts){
-		return stealCordova.runCli(opts, {
-			command: ["platform"]
-		});
-	};
-
-	stealCordova.build = function(buildResult){
-		return stealCordova.initIfNeeded().then(function(){
-			var config = buildResult.configuration;
-			var destPath = config.dest || config.bundlesPath;
-
-			return stealCordova.copyProductionFiles(destPath);
-		}).then(function(){
-			return stealCordova.runCli({}, {
-				command: ["build"],
-				args: ["--release"]
-			});
-		});
-	};
-
-	stealCordova.android = {
-		emulate: function(opts){
-			return stealCordova.runCli(opts, {
-				command: "emulate",
-				platforms: ["android"]
-			});
-		},
-		run: function(opts){
-
-		}
-	};
-
-	stealCordova.ios = {
-		emulate: function(opts){
-			return stealCordova.runCli(opts, {
-				command: "emulate",
-				platforms: ["ios"]
-			});
-		}
-	};
-
-	stealCordova.runCli = function(/* opts */){
-		var args = slice.call(arguments);
-		args.unshift(cordovaOptions);
-		args.unshift({});
-
-		var opts = extend.apply(null, args);
-		var promise = cli(opts);
-
-		return promise;
-	};
-
-	return stealCordova;
 };
 
 function setAliases(options){
@@ -136,3 +15,9 @@ function setAliases(options){
 		}
 	});
 }
+
+module.exports = function(cordovaOptions) {
+	setAliases(cordovaOptions);
+
+	return new StealCordova(cordovaOptions);
+};

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -1,0 +1,15 @@
+function Platform(stealCordova, platform) {
+	this.stealCordova = stealCordova;
+	this.platform = platform;
+
+	this.emulate = this.emulate.bind(this);
+}
+
+Platform.prototype.emulate = function(opts){
+		return this.stealCordova.runCli(opts, {
+			command: "emulate",
+			platforms: [this.platform]
+		});
+};
+
+module.exports = Platform;

--- a/lib/steal-cordova.js
+++ b/lib/steal-cordova.js
@@ -1,0 +1,109 @@
+var asap = require("pdenodeify");
+var assert = require("assert");
+var cli = require("./cordovacli")();
+var extend = require("xtend");
+var fse = require("fs-extra");
+var path = require("path");
+var Platform = require("./platform");
+var Promise = require("es6-promise").Promise;
+
+var copy = asap(fse.copy);
+var glob = asap(require("multi-glob").glob);
+var slice = Array.prototype.slice;
+
+function StealCordova(options) {
+	this.options = options;
+
+	var stealCordova = this;
+
+	this.android = new Platform(this, "android");
+	this.ios = new Platform(this, "ios");
+
+	// Bind the public method so people can do
+	// stealToolsBuild().then(stealCordova.build);
+	this.build = this.build.bind(this);
+}
+
+StealCordova.prototype = {
+	init: function(opts){
+		return this.runCli(opts, {
+			command: ["create", "platform", "plugin"]
+		});
+	},
+	// Only initialize if it hasn't already been.
+	initIfNeeded: function(opts){
+		var buildPath = (opts && opts.path) || this.options.path;
+		assert(!!buildPath, "Path needs to be provided");
+
+		var p = path.resolve(buildPath);
+		var stealCordova = this;
+
+		return new Promise(function(resolve, reject){
+			fse.exists(p, function(doesExist){
+				if(doesExist) {
+					resolve();
+				} else {
+					stealCordova.init(opts)
+					.then(function() {
+						resolve();
+					})
+					.catch(reject);
+				}
+			});
+		});
+	},
+	copyProductionFiles: function(bundlesPath){
+		var cordovaOptions = this.options;
+		var index = path.resolve(cordovaOptions.index);
+		var dest = path.resolve(cordovaOptions.path, "www/");
+
+		var files = cordovaOptions.files || cordovaOptions.glob || [];
+		files.unshift(bundlesPath);
+
+		return glob(files).then(function(files){
+			var copies = files.map(function(file){
+				return copy(file, destPath(file));
+			});
+			// copy the index.html file
+			copies.push(copy(index, path.join(dest, "index.html")));
+
+			return Promise.all(copies);
+		});
+
+
+		function destPath(p){
+			return path.join(dest, path.relative(process.cwd(), p));
+		}
+	},
+	platform: function(opts){
+		return this.runCli(opts, {
+			command: ["platform"]
+		});
+	},
+	build: function(buildResult){
+		var stealCordova = this;
+		return stealCordova.initIfNeeded().then(function(){
+			var config = buildResult.configuration;
+			var destPath = config.dest || config.bundlesPath;
+
+			return stealCordova.copyProductionFiles(destPath);
+		}).then(function(){
+			return stealCordova.runCli({}, {
+				command: ["build"],
+				args: ["--release"]
+			});
+		});
+	},
+	runCli: function(/* opts */){
+		var args = slice.call(arguments);
+		args.unshift(this.options);
+		args.unshift({});
+
+		var opts = extend.apply(null, args);
+		var promise = cli(opts);
+
+		return promise;
+	}
+};
+
+module.exports = StealCordova;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -6,7 +6,6 @@ exports.command = function(commands){
 };
 
 exports.create = function(buildDir){
-	console.log('creating', buildDir)
 	return new Promise(function(resolve, reject){
 		fse.ensureDir(buildDir, function(err){
 			if(err) {


### PR DESCRIPTION
This refactors the package for improved readability. StealCordova
becomes a type and the methods are part of its prototype.

API stays the same.