### PR TITLE
Set the steal tag's "env"

### DIFF
--- a/lib/steal-cordova.js
+++ b/lib/steal-cordova.js
@@ -1,5 +1,6 @@
 var asap = require("pdenodeify");
 var assert = require("assert");
+var cheerio = require("cheerio");
 var cli = require("./cordovacli")();
 var extend = require("xtend");
 var fse = require("fs-extra");
@@ -8,6 +9,9 @@ var Platform = require("./platform");
 var Promise = require("es6-promise").Promise;
 
 var copy = asap(fse.copy);
+var readFile = asap(fse.readFile);
+var writeFile = asap(fse.writeFile);
+var ensureFile = asap(fse.ensureFile);
 var glob = asap(require("multi-glob").glob);
 var slice = Array.prototype.slice;
 
@@ -53,8 +57,8 @@ StealCordova.prototype = {
 		});
 	},
 	copyProductionFiles: function(bundlesPath){
+		var stealCordova = this;
 		var cordovaOptions = this.options;
-		var index = path.resolve(cordovaOptions.index);
 		var dest = path.resolve(cordovaOptions.path, "www/");
 
 		var files = cordovaOptions.files || cordovaOptions.glob || [];
@@ -65,7 +69,7 @@ StealCordova.prototype = {
 				return copy(file, destPath(file));
 			});
 			// copy the index.html file
-			copies.push(copy(index, path.join(dest, "index.html")));
+			copies.push(stealCordova.copyIndexHTML(dest));
 
 			return Promise.all(copies);
 		});
@@ -74,6 +78,36 @@ StealCordova.prototype = {
 		function destPath(p){
 			return path.join(dest, path.relative(process.cwd(), p));
 		}
+	},
+	copyIndexHTML: function(dest){
+		var index = path.resolve(this.options.index);
+		var indexDest = path.join(dest, "index.html");
+
+		var readAndEnsure = Promise.all([
+			readFile(index, "utf8"),
+			ensureFile(indexDest)
+		])
+		.then(function(resolutions){
+			// Set the steal script tag's "env" variable to cordova-production
+			var txt = resolutions[0];
+			var $ = cheerio.load(txt);
+			var stealScript;
+			$("script").each(function(idx, el){
+				var $el = $(el);
+				var src = $el.attr("src");
+				if(/steal\.production\.js/.test(src)) {
+					stealScript = $el;
+					return false;
+				}
+			});
+
+			if(stealScript) {
+				stealScript.attr("env", "cordova-production");
+				return writeFile(indexDest, $.html(), "utf8")
+			} else {
+				return copy(index, indexDest);
+			}
+		});
 	},
 	platform: function(opts){
 		return this.runCli(opts, {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/stealjs/steal-cordova",
   "dependencies": {
     "async": "^2.1.4",
+    "cheerio": "^0.22.0",
     "cordova": "^6.4.0",
     "es6-promise": "^4.0.5",
     "fs-extra": "^1.0.0",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -28,3 +28,12 @@ exports.shimRunCli = function(stealCordova, cordovaOptions){
 		}
 	};
 };
+
+exports.rmdir = function(){
+	return new Promise(function(resolve, reject){
+		fse.remove(__dirname + "/build", function(err){
+			if(err) return reject(err);
+			resolve();
+		});
+	});
+}

--- a/test/test.js
+++ b/test/test.js
@@ -3,39 +3,46 @@ var fse = require("fs-extra");
 var exists = fse.existsSync;
 var makeStealCordova = require("../lib/main");
 var helpers = require("./helpers");
+var cheerio = require("cheerio");
 
 describe("steal-cordova", function(){
 	beforeEach(function(done){
-		fse.remove(__dirname + "/build", function(err){
-			if(err) return done(err);
-			done();
+		helpers.rmdir(__dirname + "/build")
+		.then(function(){
+			var cordovaOptions = {
+				buildDir: __dirname + "/build/cordova",
+				id: "com.some.app",
+				name: "some-app",
+				platforms: ["ios"],
+				plugins: ["cordova-plugin-transport-security"],
+				index: __dirname + "/tests/app/production.html"
+			};
+
+			var stealCordova = makeStealCordova(cordovaOptions);
+			helpers.shimRunCli(stealCordova, cordovaOptions);
+
+			var buildResult = {
+				configuration: {
+					dest: __dirname + "/tests/app/dist"
+				}
+			};
+
+			stealCordova.build(buildResult).then(function(){
+				done();
+			}, done);
 		});
 	});
 
-	it("works", function(done){
-		var cordovaOptions = {
-			buildDir: __dirname + "/build/cordova",
-			id: "com.some.app",
-			name: "some-app",
-			platforms: ["ios"],
-			plugins: ["cordova-plugin-transport-security"],
-			index: __dirname + "/tests/app/production.html"
-		};
-
-		var stealCordova = makeStealCordova(cordovaOptions);
-		helpers.shimRunCli(stealCordova, cordovaOptions);
-
-		var buildResult = {
-			configuration: {
-				dest: __dirname + "/tests/app/dist"
-			}
-		};
-
-		stealCordova.build(buildResult)
-		.then(function(){
-			assert(exists(__dirname + "/build/cordova/www/test/tests/app/dist/bundle.js"));
-			assert(exists(__dirname + "/build/cordova/www/index.html"));
-		})
-		.then(done, done);
+	it("Copies over the production files", function(){
+		assert(exists(__dirname + "/build/cordova/www/test/tests/app/dist/bundle.js"));
+		assert(exists(__dirname + "/build/cordova/www/index.html"));
 	});
+
+	it("Sets the Steal environment", function(){
+		var txt = fse.readFileSync(__dirname + "/build/cordova/www/index.html", "utf8");
+		var $ = cheerio.load(txt);
+
+		var env = $("script").attr("env");
+		assert.equal(env, "cordova-production", "Sets the proper Node env");
+	})
 });


### PR DESCRIPTION
When copying over the files to the cordova destination, update the Steal
tag's "env" attribute to be "steal-cordova".

Closes #9